### PR TITLE
Update emulator launch config for SWA CLI 0.8.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "command": "swa start http://localhost:3000 --api http://localhost:7071",
+      "command": "swa start http://localhost:3000 --api-location http://localhost:7071",
       "name": "Run emulator",
       "request": "launch",
       "type": "node-terminal"


### PR DESCRIPTION
The shorthand `app` and `api` options have been removed in favor of `api-location` and `app-location`. See https://github.com/Azure/static-web-apps-cli/pull/320

This change is needed to work with SWA CLI v0.8.0. And is backwards compatible with earlier versions.